### PR TITLE
Upgrade release workflow to node@16

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,10 +12,10 @@ jobs:
       - name: Prepare repository
         run: git fetch --unshallow --tags
 
-      - name: Use Node.js 14.x
+      - name: Use Node.js 16.x
         uses: actions/setup-node@v1
         with:
-          node-version: 14.x
+          node-version: 16.x
 
       - name: Install dependencies
         uses: bahmutov/npm-install@v1


### PR DESCRIPTION
Testing out the release GH workflow & debugging for @Marklb 

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>0.0.13--canary.3.400819a.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @storybook/testing-angular@0.0.13--canary.3.400819a.0
  # or 
  yarn add @storybook/testing-angular@0.0.13--canary.3.400819a.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
