### PR TITLE
Use manual GH token

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,7 @@ jobs:
 
       - name: Create Release
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |
           yarn release


### PR DESCRIPTION
Trying to debug the auto release workflow
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>1.0.1--canary.4.c90e147.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @storybook/testing-angular@1.0.1--canary.4.c90e147.0
  # or 
  yarn add @storybook/testing-angular@1.0.1--canary.4.c90e147.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->

<!-- GITHUB_RELEASE PR BODY: prerelease-version -->
# Version

Published prerelease version: `v1.0.1-next.0`

<details>
  <summary>Changelog</summary>

  #### 🐛 Bug Fix
  
  - Use manual GH token [#4](https://github.com/storybookjs/testing-angular/pull/4) ([@shilman](https://github.com/shilman))
  - Upgrade release workflow to node@16 [#3](https://github.com/storybookjs/testing-angular/pull/3) ([@shilman](https://github.com/shilman))
  
  #### ⚠️ Pushed to `next`
  
  - Refactor for Storybook v7 ([@Marklb](https://github.com/Marklb))
  
  #### Authors: 2
  
  - Mark Berry ([@Marklb](https://github.com/Marklb))
  - Michael Shilman ([@shilman](https://github.com/shilman))
</details>
<!-- GITHUB_RELEASE PR BODY: prerelease-version -->
